### PR TITLE
File size change

### DIFF
--- a/frontend/src/components/retailer/EditProduct.jsx
+++ b/frontend/src/components/retailer/EditProduct.jsx
@@ -209,7 +209,7 @@ export default function EditProduct({ isOpen, onClose, onProductUpdated, product
                 continue;
             }
             if (file.size > maxSize) {
-                toast.error(`${file.name} is too large. Maximum size is 10MB`);
+                toast.error(`${file.name} is too large. Maximum size is ${maxSize / (1024 * 1024)}MB`);
                 continue;
             }
             validFiles.push(file);

--- a/frontend/src/config/image_upload.js
+++ b/frontend/src/config/image_upload.js
@@ -1,4 +1,4 @@
-export const fileSize = 10 * 1024 * 1024; // 10MB
+export const fileSize = 3 * 1024 * 1024; // 3MB
 
 export const getMaxFileSize = () => fileSize;
 


### PR DESCRIPTION
This pull request reduces the maximum allowed image upload size and ensures that the error message shown to users accurately reflects the configured limit.

File upload size restriction:

* Reduced the maximum allowed image upload size from 10MB to 3MB by updating the `fileSize` constant in `image_upload.js`.

User feedback improvement:

* Updated the error message in `EditProduct.jsx` to dynamically display the current maximum file size, ensuring consistency with the configured limit.