### PR TITLE
Add Product fix for brand

### DIFF
--- a/app/routes/product_with_images.py
+++ b/app/routes/product_with_images.py
@@ -22,6 +22,7 @@ s3_service = S3Service()
 async def create_product_with_images(
     name: str = Form(...),
     description: str = Form(...),
+    brand: Optional[str] = Form(...),
     price: float = Form(...),
     category_id: int = Form(...),
     retailer_id: Optional[int] = Form(None),
@@ -104,6 +105,7 @@ Material sustainability: {material_sustainability}
         new_product = Product(
             name=name,
             description=description,
+            brand=brand if brand else None,
             price=Decimal(str(price)),
             quantity=stock_quantity,
             category_id=category_id,


### PR DESCRIPTION
This pull request adds support for an optional brand field when creating a product with images. The main change is to allow the brand to be submitted and stored with the product if provided.

Product creation enhancements:

* Added an optional `brand` field to the `create_product_with_images` endpoint, allowing clients to specify a brand when creating a product. (`app/routes/product_with_images.py`)
* Updated the product creation logic to store the `brand` value in the database if it is provided in the request. (`app/routes/product_with_images.py`)