### PR TITLE
Increases max items on home page as  well as auto updating the produc…

### DIFF
--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -24,7 +24,7 @@ export default function Home() {
     try {
       const api = "someKey"; // Replace with your actual API key
       const fromItem = 0;
-      const count = 40;
+      const count = 100;
 
       const apiFilters = {};
       if(filters.category) {


### PR DESCRIPTION
This pull request updates the product listing and dashboard refresh logic for the retailer dashboard. The main improvements are increasing the number of products fetched on the home page and ensuring the retailer dashboard reloads its data from the backend after a product is added, rather than updating the state optimistically.

**Product fetching and dashboard refresh improvements:**

* Increased the number of products fetched on the home page from 40 to 100 to display more products to users.

**Retailer dashboard data consistency and refresh:**

* Changed the `handleProductAdded` function in `RetailerDashboard.jsx` to fetch updated metrics and product lists from the backend after a product is added, ensuring the dashboard displays the latest data instead of just prepending the new product to the state.
* Added a `reload` dependency to the dashboard's `useEffect` hook to allow reloading dashboard data when necessary. [[1]](diffhunk://#diff-3f562db01ad03dcf4c13b0dff35d37132826610dbeef90df90dd5b6e9929e7b1R16) [[2]](diffhunk://#diff-3f562db01ad03dcf4c13b0dff35d37132826610dbeef90df90dd5b6e9929e7b1L160-R205)