### PR TITLE
196 admin monthly orders graph integration

### DIFF
--- a/app/routes/admin_orders.py
+++ b/app/routes/admin_orders.py
@@ -1,8 +1,8 @@
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 from app.db.session import get_db 
-from app.schemas.admin import AdminOrderOverviewRequest, AdminOrderOverviewResponse, AdminOrderListResponse
-from app.services.admin_overview_services import get_orders_overview, get_orders_list
+from app.schemas.admin import AdminOrderOverviewRequest, AdminOrderOverviewResponse, AdminOrderListResponse, AdminMonthlyOrdersResponse
+from app.services.admin_overview_services import get_orders_overview, get_orders_list, get_monthly_orders
 
 router = APIRouter(prefix="/admin/orders", tags=["Admin"])
 
@@ -13,3 +13,7 @@ def admin_orders_overview(request: AdminOrderOverviewRequest, db: Session = Depe
 @router.get("/list", response_model=AdminOrderListResponse)
 def admin_orders_list(db: Session = Depends(get_db)):
     return get_orders_list(db)
+
+@router.get("/monthly/{period}", response_model=AdminMonthlyOrdersResponse)
+def get_monthly_orders_endpoint(period: int, db: Session = Depends(get_db)):
+    return get_monthly_orders(period, db)

--- a/app/schemas/admin.py
+++ b/app/schemas/admin.py
@@ -43,3 +43,9 @@ class AdminOrderListResponse(BaseModel):
     status: int
     message: str
     orders: list[AdminOrderList]
+
+class AdminMonthlyOrdersResponse(BaseModel):
+    status: int
+    message: str
+    orders: list[int]
+    months: list[str]

--- a/frontend/src/components/admin/elements/DashboardMetricsChart.jsx
+++ b/frontend/src/components/admin/elements/DashboardMetricsChart.jsx
@@ -106,7 +106,7 @@ const DashboardMetricsChart = ({ adminMetrics, loading = false }) => {
           },
           chartOptions: {
             xAxis: {
-              categories: ['03', '04', '05', '06', '07', '08', '09', '10', '11', '12', '13', '14', '15', '16'],
+              categories: adminMetrics.monthly_orders.map(item => item.month),
               labels: {
                 style: {
                   fontSize: '10px'
@@ -119,17 +119,17 @@ const DashboardMetricsChart = ({ adminMetrics, loading = false }) => {
           condition: {
             maxWidth: 480
           },
-          chartOptions: {
-            xAxis: {
-              categories: ['3', '4', '5', '6', '7', '8', '9', '10', '11', '12', '13', '14', '15', '16'],
-              labels: {
-                step: 2,
-                style: {
-                  fontSize: '9px'
-                }
-              }
-            }
-          }
+          // chartOptions: {
+          //   xAxis: {
+          //     categories: ['Test', '4', '5', '6', '7', '8', '9', '10', '11', '12', '13', '14', '15', '16'],
+          //     labels: {
+          //       step: 2,
+          //       style: {
+          //         fontSize: '9px'
+          //       }
+          //     }
+          //   }
+          // }
         }
       ]
     }
@@ -164,7 +164,7 @@ const DashboardMetricsChart = ({ adminMetrics, loading = false }) => {
         <h3 className="chart-title">Monthly Orders</h3>
         <div className="chart-controls">
           <div className="dropdown-container" ref={exportRef}>
-            <button 
+            {/* <button 
               className="dropdown-btn"
               onClick={() => {
                 setExportDropdown(!exportDropdown);
@@ -172,8 +172,8 @@ const DashboardMetricsChart = ({ adminMetrics, loading = false }) => {
               }}
             >
               Export data <span className="dropdown-arrow">⌄</span>
-            </button>
-            {exportDropdown && (
+            </button> */}
+            {/* {exportDropdown && (
               <div className="dropdown-menu">
                 <div className="dropdown-item" onClick={() => handleExportClick('CSV')}>
                   Export as CSV
@@ -185,9 +185,9 @@ const DashboardMetricsChart = ({ adminMetrics, loading = false }) => {
                   Export as Excel
                 </div>
               </div>
-            )}
+            )} */}
           </div>
-          <div className="dropdown-container" ref={periodRef}>
+          {/* <div className="dropdown-container" ref={periodRef}>
             <button 
               className="dropdown-btn"
               onClick={() => {
@@ -210,7 +210,7 @@ const DashboardMetricsChart = ({ adminMetrics, loading = false }) => {
                 </div>
               </div>
             )}
-          </div>
+          </div> */}
         </div>
       </div>
       


### PR DESCRIPTION
This pull request adds a new backend API endpoint and response schema to provide monthly order statistics for the admin dashboard, and updates the frontend to consume and display this data dynamically. It also includes some frontend refactoring and temporary disabling of certain dropdown controls.

**Backend: Monthly Orders API**

* Added a new endpoint `GET /admin/orders/monthly/{period}` returning monthly order counts and month names for a selected period (6, 12, or 24 months). This includes a new response schema `AdminMonthlyOrdersResponse` and a service method `get_monthly_orders`. [[1]](diffhunk://#diff-776cdcae0e41644741e5b2143eea163b0b612131bb3af687c0bf6362469362d9L4-R5) [[2]](diffhunk://#diff-776cdcae0e41644741e5b2143eea163b0b612131bb3af687c0bf6362469362d9R16-R19) [[3]](diffhunk://#diff-066a7a8572023aa1556af3a92a1e392ea1ee8a67080673f01712b297c69252fdR46-R51) [[4]](diffhunk://#diff-67ed9482b1e9fad36e47c2580720ca0d4746d74ac688c19969ce20933409db57R8) [[5]](diffhunk://#diff-67ed9482b1e9fad36e47c2580720ca0d4746d74ac688c19969ce20933409db57R80-R120)

**Frontend: Dashboard Chart Integration**

* Updated the `DashboardMetricsChart` component to use the backend-provided month names for the x-axis categories, ensuring the chart is dynamically populated based on API data.
* Commented out (temporarily disabled) the export and period selection dropdown controls in the chart UI, likely for future refactoring or pending backend support. [[1]](diffhunk://#diff-c5913fbef2b31ec3d6521f93e5d2047ef8c29c46ff1132b9888d1f16e18f7cc5L122-R132) [[2]](diffhunk://#diff-c5913fbef2b31ec3d6521f93e5d2047ef8c29c46ff1132b9888d1f16e18f7cc5L167-R176) [[3]](diffhunk://#diff-c5913fbef2b31ec3d6521f93e5d2047ef8c29c46ff1132b9888d1f16e18f7cc5L188-R190) [[4]](diffhunk://#diff-c5913fbef2b31ec3d6521f93e5d2047ef8c29c46ff1132b9888d1f16e18f7cc5L213-R213)