### PR TITLE
Refactor total retailers count query to group by user ID for accurate…

### DIFF
--- a/app/routes/admin_metrics.py
+++ b/app/routes/admin_metrics.py
@@ -17,7 +17,7 @@ router = APIRouter(prefix="/admin", tags=["Admin"])
 @router.get("/metrics")
 def get_admin_metrics(db: Session = Depends(get_db)):
     total_users = db.query(User).count()
-    total_retailers = db.query(RetailerInformation).count()
+    total_retailers = db.query(RetailerInformation.user_id).group_by(RetailerInformation.user_id).count()
     total_products = db.query(Product).count()
     
     # Get verified and unverified product counts


### PR DESCRIPTION
This pull request updates the admin metrics endpoint to improve the calculation of the total number of retailers. Instead of counting all entries in the `RetailerInformation` table, it now counts the number of unique users with retailer information.

Metrics calculation improvement:
* The `total_retailers` metric now counts distinct `user_id`s in `RetailerInformation`, providing an accurate count of unique retailers instead of total rows. (`app/routes/admin_metrics.py`)… metrics