### PR TITLE
199 admin revenue overview integration

### DIFF
--- a/app/routes/admin_orders.py
+++ b/app/routes/admin_orders.py
@@ -1,8 +1,8 @@
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 from app.db.session import get_db 
-from app.schemas.admin import AdminOrderOverviewRequest, AdminOrderOverviewResponse, AdminOrderListResponse, AdminMonthlyOrdersResponse
-from app.services.admin_overview_services import get_orders_overview, get_orders_list, get_monthly_orders
+from app.schemas.admin import AdminOrderOverviewRequest, AdminOrderOverviewResponse, AdminOrderListResponse, AdminMonthlyOrdersResponse, AdminRevenueOverviewResponse
+from app.services.admin_overview_services import get_orders_overview, get_orders_list, get_monthly_orders, get_revenue_overview
 
 router = APIRouter(prefix="/admin/orders", tags=["Admin"])
 
@@ -17,3 +17,7 @@ def admin_orders_list(db: Session = Depends(get_db)):
 @router.get("/monthly/{period}", response_model=AdminMonthlyOrdersResponse)
 def get_monthly_orders_endpoint(period: int, db: Session = Depends(get_db)):
     return get_monthly_orders(period, db)
+
+@router.get("/revenue/{period}", response_model=AdminRevenueOverviewResponse)
+def get_revenue_overview_endpoint(period: int, db: Session = Depends(get_db)):
+    return get_revenue_overview(period, db)

--- a/app/schemas/admin.py
+++ b/app/schemas/admin.py
@@ -49,3 +49,10 @@ class AdminMonthlyOrdersResponse(BaseModel):
     message: str
     orders: list[int]
     months: list[str]
+
+class AdminRevenueOverviewResponse(BaseModel):
+    status: int
+    message: str
+    total_revenue: float
+    lost_revenue: float
+    monthly_comparison: float

--- a/app/services/admin_overview_services.py
+++ b/app/services/admin_overview_services.py
@@ -2,10 +2,13 @@ from sqlalchemy.orm import Session
 from app.models.orders import Order
 from app.models.user import User
 from app.models.address import Address
+from app.models.cart_item import CartItem
+from app.models.product import Product
 from datetime import date
 from datetime import timedelta
 from sqlalchemy import extract
 from calendar import month_name
+from decimal import Decimal
 
 def get_orders_overview(request, db: Session):
     if request.time == 1:
@@ -24,21 +27,19 @@ def get_orders_overview(request, db: Session):
     TotalDelivered = db.query(Order).filter(Order.state == 'Delivered', Order.created_at >= time_filter).count()
     TotalCancelled = db.query(Order).filter(Order.state == 'Cancelled', Order.created_at >= time_filter).count()
 
-    today = date.today()
-    first_day_this_month = today.replace(day=1)
-    first_day_last_month = (first_day_this_month - timedelta(days=1)).replace(day=1)
-    last_day_last_month = first_day_this_month - timedelta(days=1)
+    this_month = date.today().month
+    last_month = this_month - 1 if this_month > 1 else 12
 
-    current_month_orders = db.query(Order).filter( Order.created_at >= first_day_this_month, Order.created_at <= today ).count()
+    current_month_orders = db.query(Order).filter(Order.state != 'Cancelled', extract('month', Order.created_at) == this_month).count()
 
-    last_month_orders = db.query(Order).filter( Order.created_at >= first_day_last_month, Order.created_at <= last_day_last_month ).count()
+    last_month_orders = db.query(Order).filter(Order.state != 'Cancelled', extract('month', Order.created_at) == last_month).count()
 
     if last_month_orders == 0:
         percent_change = 1.0 if current_month_orders > 0 else 0.0
     else:
         percent_change = (current_month_orders - last_month_orders) / last_month_orders
 
-    percentage_increase = percent_change
+    percentage_increase = round(percent_change, 2)
     # print("\n\n\n\n" + str(percentage_increase) + "\n\n\n\n")
 
     return {
@@ -118,3 +119,79 @@ def get_monthly_orders(period, db: Session):
         "months": month_names
     }
 
+def get_revenue_overview(period, db: Session):
+    if period == 1:
+        time_filter = date.today()
+    elif period == 2:
+        time_filter = date.today() - timedelta(days=7)
+    elif period == 3:
+        time_filter = date.today() - timedelta(days=30)
+    else:
+        time_filter = date.today() - timedelta(days=365)
+
+    
+    orders = db.query(Order).filter(Order.created_at >= time_filter, Order.state != 'Cancelled').all()
+    lost_orders = db.query(Order).filter(Order.created_at >= time_filter, Order.state == 'Cancelled').all()
+    cart_items = db.query(CartItem).all()
+    products = db.query(Product).all()
+
+    total_revenue = Decimal('0.0')
+    lost_revenue = Decimal('0.0')
+
+    for o in orders:
+        for c in cart_items:
+            if c.cart_id == o.cart_id:
+                for p in products:
+                    if p.id == c.product_id:
+                        total_revenue += p.price * c.quantity
+                        break
+
+    for o in lost_orders:
+        for c in cart_items:
+            if c.cart_id == o.cart_id:
+                for p in products:
+                    if p.id == c.product_id:
+                        lost_revenue += p.price * c.quantity
+                        break
+            
+
+    this_month = date.today().month
+    last_month = this_month - 1 if this_month > 1 else 12
+
+    # These Two
+    current_month_orders = db.query(Order).filter(Order.state != 'Cancelled', extract('month', Order.created_at) == this_month).all()
+    last_month_orders = db.query(Order).filter(Order.state != 'Cancelled', extract('month', Order.created_at) == last_month).all()
+
+    last_month_revenue = Decimal('0.0')
+    this_month_revenue = Decimal('0.0')
+
+    for o in current_month_orders:
+        for c in cart_items:
+            if c.cart_id == o.cart_id:
+                for p in products:
+                    if p.id == c.product_id:
+                        this_month_revenue += p.price * c.quantity
+                        break
+
+    for o in last_month_orders:
+        for c in cart_items:
+            if c.cart_id == o.cart_id:
+                for p in products:
+                    if p.id == c.product_id:
+                        last_month_revenue += p.price * c.quantity
+                        break
+
+    if last_month_revenue == '0.0':
+        percent_change = '1.0' if this_month_revenue > '0.0' else '0.0'
+    else:
+        percent_change = (this_month_revenue - last_month_revenue) / last_month_revenue
+
+    percentage_increase = round(percent_change, 2)
+
+    return {
+        "status": 200,
+        "message": "Revenue overview fetched successfully",
+        "total_revenue": float(total_revenue),
+        "lost_revenue": float(lost_revenue), 
+        "monthly_comparison": float(percentage_increase)
+    }

--- a/frontend/src/components/admin/elements/OrdersStatsCard.jsx
+++ b/frontend/src/components/admin/elements/OrdersStatsCard.jsx
@@ -4,7 +4,7 @@ import { getApiUrl, getLocalApiUrl } from '../../../config/api';
 
 const OrderStatsCards = () => {
   const [orderPeriod, setOrderPeriod] = useState('Day');
-  const [revenuePeriod, setRevenuePeriod] = useState('Month');
+  const [revenuePeriod, setRevenuePeriod] = useState('Day');
   const [showOrderDropdown, setShowOrderDropdown] = useState(false);
   const [showRevenueDropdown, setShowRevenueDropdown] = useState(false);
   const [pending, setPending] = useState(0);
@@ -14,9 +14,26 @@ const OrderStatsCards = () => {
   const [cancelled, setCancelled] = useState(0);
   const [total, setTotal] = useState(0);
   const [monthly, setMonthly] = useState(0.0);
+  const [totalRevenue, setTotalRevenue] = useState(0.0);
+  const [totalLoss, setTotalLoss] = useState(0.0);
+  const [monthlyChange, setMonthlyChange] = useState(0.0);
 
   const orderPeriods = ['Day', 'Week', 'Month', 'Year'];
   const revenuePeriods = ['Day', 'Week', 'Month', 'Year'];
+
+  const populateOrdersRevenue = async (period) => {
+    const apiUrl = getLocalApiUrl();
+    const response = await fetch(`${apiUrl}/admin/orders/revenue/${period}`).then(res => res.json());
+    
+    if(response){
+      setTotalRevenue(response.total_revenue || 0);
+      setTotalLoss(response.lost_revenue || 0);
+      setMonthlyChange(response.monthly_comparison * 100 || 0.0);
+    }
+
+
+
+  }
 
   const populateOrdersOverview = async (period) => {
     const apiUrl = getLocalApiUrl();
@@ -40,7 +57,8 @@ const OrderStatsCards = () => {
 
   useEffect(() => {
 	populateOrdersOverview(orderPeriods.findIndex(p => p === orderPeriod) + 1);
-  }, [orderPeriod]);
+  populateOrdersRevenue(revenuePeriods.findIndex(p => p === revenuePeriod) +1);
+  }, [orderPeriod, revenuePeriod]);
 
   useEffect(() => {
     // Order Overview Chart
@@ -110,8 +128,8 @@ const OrderStatsCards = () => {
       },
       series: [{
         data: [
-          { name: 'Online', y: 74, color: '#8b5cf6' },
-          { name: 'Cash', y: 42, color: '#f97316' }
+          { name: 'Revenue', y: totalRevenue, color: '#8b5cf6' },
+          { name: 'Lost Revenue', y: totalLoss, color: '#f97316' }
         ]
       }],
       credits: { enabled: false }
@@ -120,7 +138,7 @@ const OrderStatsCards = () => {
     return () => {
       if (revenueChart) revenueChart.destroy();
     };
-  }, [orderPeriod, revenuePeriod]);
+  }, [orderPeriod, revenuePeriod, totalRevenue, totalLoss]);
 
   const handleOrderPeriodChange = (period) => {
     setOrderPeriod(period);
@@ -243,9 +261,9 @@ const OrderStatsCards = () => {
           <div className="adm-ord-stats-value-row">
             <div className="adm-ord-stats-main">
               <div className="adm-ord-stats-label">Total Revenue</div>
-              <div className="adm-ord-stats-value">$116K</div>
+              <div className="adm-ord-stats-value">R{totalRevenue}</div>
               <div className="adm-ord-stats-change">
-                <span className="adm-ord-change negative">-7.2%</span>
+                <span className={`adm-ord-change ${monthlyChange > 0 ? 'positive' : 'negative'}`}>{monthlyChange}%</span>
                 <span className="adm-ord-comparison">Compared to last week</span>
               </div>
             </div>
@@ -259,11 +277,11 @@ const OrderStatsCards = () => {
         <div className="adm-ord-breakdown">
           <div className="adm-ord-breakdown-item">
             <span className="adm-ord-breakdown-label">Online</span>
-            <span className="adm-ord-breakdown-value" style={{borderLeft: '3px solid #8b5cf6', paddingLeft: '6px'}}>$74K</span>
+            <span className="adm-ord-breakdown-value" style={{borderLeft: '3px solid #8b5cf6', paddingLeft: '6px'}}>R{totalRevenue}</span>
           </div>
           <div className="adm-ord-breakdown-item">
             <span className="adm-ord-breakdown-label">Cash</span>
-            <span className="adm-ord-breakdown-value" style={{borderLeft: '3px solid #f97316', paddingLeft: '6px'}}>$42K</span>
+            <span className="adm-ord-breakdown-value" style={{borderLeft: '3px solid #f97316', paddingLeft: '6px'}}>R{totalLoss}</span>
           </div>
         </div>
       </div>

--- a/frontend/src/components/admin/elements/OrdersStatsCard.jsx
+++ b/frontend/src/components/admin/elements/OrdersStatsCard.jsx
@@ -129,7 +129,7 @@ const OrderStatsCards = () => {
       series: [{
         data: [
           { name: 'Revenue', y: totalRevenue, color: '#8b5cf6' },
-          { name: 'Lost Revenue', y: totalLoss, color: '#f97316' }
+          { name: 'Lost Revenue from Cancelled Orders', y: totalLoss, color: 'red' }
         ]
       }],
       credits: { enabled: false }
@@ -138,7 +138,7 @@ const OrderStatsCards = () => {
     return () => {
       if (revenueChart) revenueChart.destroy();
     };
-  }, [orderPeriod, revenuePeriod, totalRevenue, totalLoss]);
+  }, [totalRevenue, totalLoss]);
 
   const handleOrderPeriodChange = (period) => {
     setOrderPeriod(period);
@@ -264,7 +264,7 @@ const OrderStatsCards = () => {
               <div className="adm-ord-stats-value">R{totalRevenue}</div>
               <div className="adm-ord-stats-change">
                 <span className={`adm-ord-change ${monthlyChange > 0 ? 'positive' : 'negative'}`}>{monthlyChange}%</span>
-                <span className="adm-ord-comparison">Compared to last week</span>
+                <span className="adm-ord-comparison">Compared to last month</span>
               </div>
             </div>
             <div className="adm-ord-chart-container">
@@ -276,12 +276,12 @@ const OrderStatsCards = () => {
         {/* Revenue breakdown */}
         <div className="adm-ord-breakdown">
           <div className="adm-ord-breakdown-item">
-            <span className="adm-ord-breakdown-label">Online</span>
+            <span className="adm-ord-breakdown-label">Revenue</span>
             <span className="adm-ord-breakdown-value" style={{borderLeft: '3px solid #8b5cf6', paddingLeft: '6px'}}>R{totalRevenue}</span>
           </div>
           <div className="adm-ord-breakdown-item">
-            <span className="adm-ord-breakdown-label">Cash</span>
-            <span className="adm-ord-breakdown-value" style={{borderLeft: '3px solid #f97316', paddingLeft: '6px'}}>R{totalLoss}</span>
+            <span className="adm-ord-breakdown-label">Lost Revenue from Cancelled Orders</span>
+            <span className="adm-ord-breakdown-value" style={{borderLeft: '3px solid red', paddingLeft: '6px'}}>R{totalLoss}</span>
           </div>
         </div>
       </div>


### PR DESCRIPTION
This pull request introduces a new revenue overview feature for admin order statistics, updating both the backend (API and services) and the frontend dashboard. The main changes include adding a new API endpoint to fetch revenue data, calculating revenue and lost revenue on the backend, and updating the frontend to display this information dynamically.

**Backend: Revenue Overview Feature**

* Added a new API endpoint `/admin/orders/revenue/{period}` that returns revenue statistics for a given period, including total revenue, lost revenue, and monthly comparison. (`app/routes/admin_orders.py`, `app/schemas/admin.py`, `app/services/admin_overview_services.py`) [[1]](diffhunk://#diff-776cdcae0e41644741e5b2143eea163b0b612131bb3af687c0bf6362469362d9L4-R5) [[2]](diffhunk://#diff-776cdcae0e41644741e5b2143eea163b0b612131bb3af687c0bf6362469362d9R20-R23) [[3]](diffhunk://#diff-066a7a8572023aa1556af3a92a1e392ea1ee8a67080673f01712b297c69252fdR52-R58) [[4]](diffhunk://#diff-67ed9482b1e9fad36e47c2580720ca0d4746d74ac688c19969ce20933409db57R122-R197)
* Implemented the `get_revenue_overview` service, which calculates total and lost revenue by iterating over orders, cart items, and products, and computes the percentage change compared to the previous month. (`app/services/admin_overview_services.py`)

**Frontend: Revenue Overview Integration**

* Updated the `OrderStatsCards` component to fetch and display revenue statistics, including total revenue, lost revenue, and monthly change, based on the selected period. (`frontend/src/components/admin/elements/OrdersStatsCard.jsx`) [[1]](diffhunk://#diff-23ff576fc30a1b2e7c85c78b160b4135bde9ed3c91063cb6bdd508c779886eebR17-R37) [[2]](diffhunk://#diff-23ff576fc30a1b2e7c85c78b160b4135bde9ed3c91063cb6bdd508c779886eebL43-R61)
* Modified the revenue chart and breakdown sections to use dynamic values from the API instead of hardcoded placeholders. (`frontend/src/components/admin/elements/OrdersStatsCard.jsx`) [[1]](diffhunk://#diff-23ff576fc30a1b2e7c85c78b160b4135bde9ed3c91063cb6bdd508c779886eebL113-R132) [[2]](diffhunk://#diff-23ff576fc30a1b2e7c85c78b160b4135bde9ed3c91063cb6bdd508c779886eebL246-R266) [[3]](diffhunk://#diff-23ff576fc30a1b2e7c85c78b160b4135bde9ed3c91063cb6bdd508c779886eebL262-R284)
* Changed the default revenue period to 'Day' to match the new API and ensure correct initial data display. (`frontend/src/components/admin/elements/OrdersStatsCard.jsx`)

These changes provide admins with real-time, accurate revenue insights and comparisons, improving the analytics capabilities of the dashboard.